### PR TITLE
Fixes & more

### DIFF
--- a/lib/roar/rails/responder.rb
+++ b/lib/roar/rails/responder.rb
@@ -5,13 +5,14 @@ module Roar::Rails
       resource.extend(representer)
     end
     def display(resource, given_options={})
+      representer = given_options.delete(:with_representer)
       if resource.respond_to?(:map!)
         resource.map! do |r|
-          extend_with_representer!(r)
-          r.to_hash
+          extend_with_representer!(r, representer)
+          r.respond_to?(:to_hash) ? r.to_hash : r
         end
       else
-        extend_with_representer!(resource, options.delete(:with_representer))
+        extend_with_representer!(resource, representer)
       end
       super
     end


### PR DESCRIPTION
Hi there Nick!

I had a bunch of problems, some were solved by the attached commit.
Basically what brought me there was "undefined method to_hash", when only using the Roar::Representer::XML module. First I tried including _both_ Roar::Representer::JSON and Roar::Representer::XML (in that order), that way to_hash is there (from Representable::JSON I suppose). The XML output wasn't as expected, though. Every object wrapped in a <object/> tag and the whole collection was called <objects/>.
The name of the collection tag is correct, after applying the attached commit and _not_ including Roar::Representer::JSON. Works for me. However, the collection tag ended up empty. So I started digging.

What I came up with at last, is this:

``` ruby
module ArrayRepresenter
  def to_xml(options={})
    options = options.dup
    options[:indent]  ||= 2
    options[:root]    ||= if first.class.to_s != "Hash" && all? { |e| e.is_a?(first.class) }
      underscored = ActiveSupport::Inflector.underscore(first.class.name)
      ActiveSupport::Inflector.pluralize(underscored).tr('_', '-').tr('/', '_')
    else
      "objects"
    end

    doc = Nokogiri::XML::Document.new
    doc.root = Nokogiri::XML::Element.new(options[:root], doc)
    doc.root['type'] = 'array' unless options[:skip_types]
    child_name = ActiveSupport::Inflector.singularize(options[:root])
    each do |element|
      doc.root.add_child(element.to_node(:wrap => child_name))
    end
    return doc.to_xml
  end
end
```

It is roughly based on active_support/core_ext/array/conversion.rb, but uses Nokogiri to be compatible with to_node, instead of Builder::XmlMarkup/ActiveSupport::MiniXml (the purpose of which is totally lost on me...).

To use it I needed to put in the controller (I'm using inherited_resources by Jose Valim):

``` ruby
  private

  def end_of_association_chain
    super.extend(ArrayRepresenter)
  end
```

I'm pretty sure this isn't at all how you intended this to be used.

To conclude: either a) I'm missing something or b) you were drunk when you wrote this. Tell me which :)

Take care.

Niklas

P.S.: Another side-node: when using the XML representer I get elements called like "user_id", when I would expect it to be "user-id" (that's what the default ActiveRecord::Base#to_xml generates). It's not really a big issue, but quite annoying when you're migrating from using plain to_xml to using representers. To keep the old version, I adjusted the ArrayRepresenter above and wrote another module:

``` ruby
require 'roar/representer/xml'
module Roar::Representer::DashXML
  def self.included(base)
    base.send(:include, Roar::Representer::XML)
    base.extend(ClassMethods)
  end

  module ClassMethods
    def property(name, options={})
      super(name, { :from => name.to_s.tr('_', '-') }.merge(options))
    end
  end
end

```
