### PR TITLE
Fixed URL Helpers example in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -96,6 +96,7 @@ module FruitRepresenter
   link :self do
     fruit_url self
   end
+end
 ```
 To get the hyperlinks up and running, please make sure to set the right _host name_ in your environment files (config/environments):
 


### PR DESCRIPTION
The Roar::Representer::Feature::Hypermedia modules needs to be included
in order to use the link method.
