### PR TITLE
set Roar.logger to Rails.logger

### DIFF
--- a/lib/roar/rails/railtie.rb
+++ b/lib/roar/rails/railtie.rb
@@ -7,6 +7,7 @@ module Roar
       config.representer = ActiveSupport::OrderedOptions.new
       
       initializer "roar.set_configs" do |app|
+        Roar.logger = ::Rails.logger
         ::Roar::Representer.module_eval do
           include app.routes.url_helpers
           include app.routes.mounted_helpers unless ::Rails::VERSION::MINOR == 0


### PR DESCRIPTION
Use the new Roar.logger witch is introduced with apotonick/roar#43

With merge of this pull request the roar-rails dependency must be settet to the new gem version of roar witch integrates apotonick/roar#43

The tests currently fails while travis use the roar gem and not the needed commit apotonick/roar#43
