### PR TITLE
Add hal renderer.

### DIFF
--- a/lib/roar/rails/renderers/hal.rb
+++ b/lib/roar/rails/renderers/hal.rb
@@ -1,0 +1,8 @@
+Mime::Type.register 'application/json+hal', :hal unless defined? Mime::HAL
+
+ActionController::Renderers.add :hal do |hal, options|
+  hal = hal.to_hal(options) unless hal.kind_of?(String)
+  hal = "#{options[:callback]}(#{hal})" unless options[:callback].blank?
+  self.content_type ||= Mime::HAL
+  self.response_body  = hal
+end

--- a/roar-rails.gemspec
+++ b/roar-rails.gemspec
@@ -17,13 +17,13 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
-  
-  s.add_runtime_dependency "roar", "~> 0.10"
+
+  s.add_runtime_dependency "roar", "~> 0.11.13"
   s.add_runtime_dependency "test_xml"
   s.add_runtime_dependency "actionpack",    "~> 3.0"
   s.add_runtime_dependency "railties",    "~> 3.0"
   s.add_runtime_dependency "hooks"
-  
+
   s.add_development_dependency "minitest",	">= 2.8.1"
   s.add_development_dependency "tzinfo" # FIXME: why the hell do we need this for 3.1?
 end

--- a/test/hal_renderer_test.rb
+++ b/test/hal_renderer_test.rb
@@ -1,0 +1,33 @@
+require 'test_helper'
+require 'roar/rails/renderers/hal'
+
+class HalRendererTest < ActionController::TestCase
+  include Roar::Rails::TestCase
+
+  class SingersController < ActionController::Base
+    respond_to :hal
+    module SingerRepresenter
+      include Roar::Representer::JSON::HAL
+
+      property :name
+    end
+
+    def show
+      singer = Musician.new("Bumi")
+      singer.extend SingerRepresenter
+      respond_with singer
+    end
+  end
+
+  tests SingersController
+
+  test "should render correctly in response to a application/json+hal request" do
+    get :show, :id => "bumi", :format => :hal
+    assert_body "{\"name\":\"Bumi\"}"
+  end
+
+  test "should have a content_type of application/json+hal" do
+    get :show, :id => "bumi", :format => :hal
+    assert_equal response.content_type, 'application/json+hal'
+  end
+end


### PR DESCRIPTION
Add `require 'roar/rails/renderers/hal'` to an initializer to begin accepting and responding with application/json+hal.  Relies on https://github.com/apotonick/roar/pull/67
