### PR TITLE
change roar dependency to `0.11.13`

### DIFF
--- a/roar-rails.gemspec
+++ b/roar-rails.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency "roar",          "~> 0.10"
+  s.add_runtime_dependency "roar",          "~> 0.11.13"
   s.add_runtime_dependency "representable", "~> 1.4"
   s.add_runtime_dependency "test_xml"
   s.add_runtime_dependency "actionpack"


### PR DESCRIPTION
`0.10` has no Decorator, `0.11.13` is the first version with it
