### PR TITLE
Add a default_render method

### DIFF
--- a/lib/roar/rails/responder.rb
+++ b/lib/roar/rails/responder.rb
@@ -1,5 +1,8 @@
 module Roar::Rails
   module Responder
+    def default_render
+      render
+    end
     def display(model, *args)
       if representer = options.delete(:represent_items_with)
         render_items_with(model, representer) # convenience API, not recommended since it's missing hypermedia.


### PR DESCRIPTION
calling "render" without this method returns a no method error in rails 4
