### PR TITLE
Set default representer config

### DIFF
--- a/lib/roar/rails/controller_additions.rb
+++ b/lib/roar/rails/controller_additions.rb
@@ -9,7 +9,7 @@ module Roar::Rails
       extend Hooks::InheritableAttribute
       inheritable_attr :represents_options
       self.represents_options ||= RepresenterComputer.new
-      before_action :set_representer_config
+      before_filter :set_representer_config
     end
 
 

--- a/lib/roar/rails/controller_additions.rb
+++ b/lib/roar/rails/controller_additions.rb
@@ -64,13 +64,10 @@ module Roar::Rails
     end
 
     def set_representer_config
-      Rails.configuration.representer.default_url_options ||= {}
-      url_options = {
-        host:     request.host,
-        port:     request.port,
-        protocol: request.protocol
-      }
-      url_options.merge!(Rails.configuration.representer.default_url_options)
+      url_options = Rails.configuration.representer.default_url_options || {}
+      url_options[:protocol] ||= request.protocol
+      url_options[:host]     ||= request.host
+      url_options[:port]     ||= request.port unless request.port == 80
       Rails.configuration.representer.default_url_options = url_options
     end
 

--- a/lib/roar/rails/controller_additions.rb
+++ b/lib/roar/rails/controller_additions.rb
@@ -9,6 +9,7 @@ module Roar::Rails
       extend Hooks::InheritableAttribute
       inheritable_attr :represents_options
       self.represents_options ||= RepresenterComputer.new
+      before_action :set_representer_config
     end
 
 
@@ -62,6 +63,16 @@ module Roar::Rails
       super
     end
 
+    def set_representer_config
+      Rails.configuration.representer.default_url_options ||= {}
+      url_options = {
+        host:     request.host,
+        port:     request.port,
+        protocol: request.protocol
+      }
+      url_options.merge!(Rails.configuration.representer.default_url_options)
+      Rails.configuration.representer.default_url_options = url_options
+    end
 
     class RepresenterComputer < Hash
       def add(format, opts)


### PR DESCRIPTION
Here is a callback method in `ControllerAdditions` allowing to send default url options to the representer config from the controller's `request`object.

This avoids having to set these options in environment config files when you want to use the current request host, port and protocol.

However, these options can still be overridden in environment config files as before (static config is merged over default one).

The `set_representer_config` method could be used to set other representer default configuration values from the controller (for now, only url options seems useful).

If you aggree with this feature, I can update the readme and/or specs.
