### PR TITLE
Gemspec: Require uber version >= 0.0.5

### DIFF
--- a/roar-rails.gemspec
+++ b/roar-rails.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "test_xml",      ">= 0.1.6"  # TODO: remove dependency as most people don't use XML.
   s.add_runtime_dependency "actionpack"
   s.add_runtime_dependency "railties",      ">= 3.0.0"
-  s.add_runtime_dependency "uber"
+  s.add_runtime_dependency "uber",          ">= 0.0.5"
 
   s.add_development_dependency "minitest",	"~> 4.0"
   s.add_development_dependency "activemodel"


### PR DESCRIPTION
Earlier versions don't support Uber::Version.
- uber changelog: https://github.com/apotonick/uber/blob/master/CHANGES.md#005
- used here: https://github.com/apotonick/roar-rails/blob/master/lib/roar-rails.rb#L24
