### PR TITLE
[Review Requested] Add scaffold_controller generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ Gemfile*.lock
 pkg/*
 test/dummy/log/*
 test/dummy/tmp/*
+test/tmp/*
 .rvmrc

--- a/Rakefile
+++ b/Rakefile
@@ -1,11 +1,16 @@
 require "bundler/gem_tasks"
-
 require 'rake/testtask'
+require "rails/version"
 
 task :default => [:test]
 
 Rake::TestTask.new(:test) do |test|
   test.libs << 'test'
-  test.test_files = FileList['test/*_test.rb']
+
+  # Do not test generators for Rails < 3.2
+  test.test_files = FileList['test/*_test.rb'].reject do |file|
+    file.include?('generator') && Rails::VERSION::STRING < '3.2'
+  end
+
   test.verbose = true
 end

--- a/gemfiles/Gemfile.rails3-0
+++ b/gemfiles/Gemfile.rails3-0
@@ -5,3 +5,4 @@ gemspec :path => '../'
 
 gem 'railties', '~> 3.0.11'
 gem 'activerecord', '~> 3.0.11'
+gem "minitest", "~> 4.0"

--- a/gemfiles/Gemfile.rails3-2
+++ b/gemfiles/Gemfile.rails3-2
@@ -6,3 +6,4 @@ gemspec :path => '../'
 
 gem 'railties', '~> 3.2.13'
 gem 'activerecord', '~> 3.2.13'
+gem "minitest", "~> 4.0"

--- a/lib/generators/rails/collection_representer_generator.rb
+++ b/lib/generators/rails/collection_representer_generator.rb
@@ -1,0 +1,70 @@
+module Rails
+  module Generators
+    class CollectionRepresenterGenerator < Rails::Generators::NamedBase
+      source_root File.expand_path("../templates", __FILE__)
+
+      argument :properties, :type => :array, :default => [],
+        :banner => "property[:class[:extend]] property[:class[:extend]]"
+
+      class_option :format, :default => :json, :banner => "--format=JSON",
+        :desc => "Use different formats JSON, JSON::HAL or XML"
+
+      def generate_representer_file
+        template('collection_representer.rb', file_path)
+      end
+
+      private
+
+      def format
+        options[:format].upcase
+      end
+
+      def property_options
+        PropertyBuilder.new(properties)
+      end
+
+      def file_path
+        base_path = 'app/representers'
+        File.join(base_path, class_path, "#{file_name.pluralize}_representer.rb")
+      end
+
+      class PropertyBuilder
+        include Enumerable
+
+        def initialize(properties)
+          @raw = properties
+        end
+
+        def each(&block)
+          properties_with_options.each(&block)
+        end
+
+        private
+
+        def properties_with_options
+          properties.map do |(name, klass, representer)|
+            p = [name_option(name)]
+            p << hash_option(:class, klass)
+            p << hash_option(:extend, representer)
+
+            p.compact.join(', ')
+          end
+        end
+
+        def name_option(name)
+          return unless name
+          "property :#{name}"
+        end
+
+        def hash_option(key, value)
+          return unless key && value
+          ":#{key} => #{value.classify}"
+        end
+
+        def properties
+          @raw.map { |p| p.split(':') }
+        end
+      end
+    end
+  end
+end

--- a/lib/generators/rails/scaffold_controller_generator.rb
+++ b/lib/generators/rails/scaffold_controller_generator.rb
@@ -8,10 +8,7 @@ module Rails
       source_root File.expand_path('../templates', __FILE__)
 
       hook_for :representer, default: true
-
-      hook_for :collection_representer, default: true  do |instance, controller|
-        instance.invoke controller, [instance.name.pluralize]
-      end
+      hook_for :collection_representer, default: true
     end
   end
 end

--- a/lib/generators/rails/scaffold_controller_generator.rb
+++ b/lib/generators/rails/scaffold_controller_generator.rb
@@ -1,0 +1,12 @@
+require 'rails/generators'
+require 'rails/generators/rails/scaffold_controller/scaffold_controller_generator'
+
+module Rails
+  module Generators
+    class ScaffoldControllerGenerator
+      source_root File.expand_path('../templates', __FILE__)
+
+      hook_for :representer, default: true
+    end
+  end
+end

--- a/lib/generators/rails/scaffold_controller_generator.rb
+++ b/lib/generators/rails/scaffold_controller_generator.rb
@@ -7,6 +7,10 @@ module Rails
       source_root File.expand_path('../templates', __FILE__)
 
       hook_for :representer, default: true
+
+      hook_for :collection_representer, default: true  do |instance, controller|
+        instance.invoke controller, [instance.name.pluralize]
+      end
     end
   end
 end

--- a/lib/generators/rails/scaffold_controller_generator.rb
+++ b/lib/generators/rails/scaffold_controller_generator.rb
@@ -1,5 +1,6 @@
-require 'rails/generators'
+require 'rails/generators/named_base'
 require 'rails/generators/rails/scaffold_controller/scaffold_controller_generator'
+require 'rails/generators/resource_helpers'
 
 module Rails
   module Generators

--- a/lib/generators/rails/templates/collection_representer.rb
+++ b/lib/generators/rails/templates/collection_representer.rb
@@ -1,0 +1,5 @@
+module <%= class_name.pluralize %>Representer
+  include Roar::Representer::<%= format %>::Collection
+
+  items extend: <%= class_name %>Representer, class: <%= class_name %>
+end

--- a/lib/generators/rails/templates/collection_representer.rb
+++ b/lib/generators/rails/templates/collection_representer.rb
@@ -1,5 +1,7 @@
+<% module_namespacing do -%>
 module <%= class_name.pluralize %>Representer
   include Roar::Representer::<%= format %>::Collection
 
   items extend: <%= class_name %>Representer, class: <%= class_name %>
 end
+<% end %>

--- a/lib/generators/rails/templates/collection_representer.rb
+++ b/lib/generators/rails/templates/collection_representer.rb
@@ -1,6 +1,6 @@
 <% module_namespacing do -%>
 module <%= class_name.pluralize %>Representer
-  include Roar::Representer::<%= format %>::Collection
+  include Representable::JSON::Collection
 
   items extend: <%= class_name %>Representer, class: <%= class_name %>
 end

--- a/lib/generators/rails/templates/controller.rb
+++ b/lib/generators/rails/templates/controller.rb
@@ -17,17 +17,17 @@ class <%= controller_class_name %>Controller < ApplicationController
   end
 
   def create
-    @<%= singular_table_name %> = consume! <%= class_name %>.new, represent_with: <%= class_name %>Representer
+    @<%= singular_table_name %> = consume! <%= class_name %>.new, :represent_with => <%= class_name %>Representer
     @<%= singular_table_name %>.save
 
     respond_with @<%= singular_table_name %>, :represent_with => <%= class_name %>Representer
   end
 
   def update
-    consume! @<%= class_name %>, :represent_with => <%= class_name %>Representer
-    @<%= class_name %>.save
+    consume! @<%= singular_table_name %>, :represent_with => <%= class_name %>Representer
+    @<%= singular_table_name %>.save
 
-    respond_with @<%= class_name %>, :represent_with => <%= class_name %>Representer
+    respond_with @<%= singular_table_name %>, :represent_with => <%= class_name %>Representer
   end
 
   def destroy

--- a/lib/generators/rails/templates/controller.rb
+++ b/lib/generators/rails/templates/controller.rb
@@ -1,0 +1,53 @@
+<% if namespaced? -%>
+require_dependency "<%= namespaced_file_path %>/application_controller"
+
+<% end -%>
+<% module_namespacing do -%>
+class <%= controller_class_name %>Controller < ApplicationController
+  before_action :set_<%= singular_table_name %>, only: [:show, :edit, :update, :destroy]
+
+  def index
+    @<%= plural_table_name %> = <%= orm_class.all(class_name) %>
+
+    respond_with @<%= plural_table_name %>, :represent_with => <%= controller_class_name %>Representer
+  end
+
+  def show
+    respond_with @<%= singular_table_name %>, :represent_with => <%= class_name %>Representer
+  end
+
+  def create
+    @<%= singular_table_name %> = consume! <%= class_name %>.new, represent_with: <%= class_name %>Representer
+    @<%= singular_table_name %>.save
+
+    respond_with @<%= singular_table_name %>, :represent_with => <%= class_name %>Representer
+  end
+
+  def update
+    consume! @<%= class_name %>, :represent_with => <%= class_name %>Representer
+    @<%= class_name %>.save
+
+    respond_with @<%= class_name %>, :represent_with => <%= class_name %>Representer
+  end
+
+  def destroy
+    @<%= orm_instance.destroy %>
+
+    head :no_content
+  end
+
+  private
+
+  def set_<%= singular_table_name %>
+    @<%= singular_table_name %> = <%= orm_class.find(class_name, "params[:id]") %>
+  end
+
+  def <%= "#{singular_table_name}_params" %>
+    <%- if attributes_names.empty? -%>
+    params[<%= ":#{singular_table_name}" %>]
+    <%- else -%>
+    params.require(<%= ":#{singular_table_name}" %>).permit(<%= attributes_names.map { |name| ":#{name}" }.join(', ') %>)
+    <%- end -%>
+  end
+end
+<% end -%>

--- a/lib/generators/rails/templates/controller.rb
+++ b/lib/generators/rails/templates/controller.rb
@@ -4,6 +4,9 @@ require_dependency "<%= namespaced_file_path %>/application_controller"
 <% end -%>
 <% module_namespacing do -%>
 class <%= controller_class_name %>Controller < ApplicationController
+  include Roar::Rails::ControllerAdditions
+  respond_to :json
+
   before_action :set_<%= singular_table_name %>, only: [:show, :edit, :update, :destroy]
 
   def index
@@ -40,14 +43,6 @@ class <%= controller_class_name %>Controller < ApplicationController
 
   def set_<%= singular_table_name %>
     @<%= singular_table_name %> = <%= orm_class.find(class_name, "params[:id]") %>
-  end
-
-  def <%= "#{singular_table_name}_params" %>
-    <%- if attributes_names.empty? -%>
-    params[<%= ":#{singular_table_name}" %>]
-    <%- else -%>
-    params.require(<%= ":#{singular_table_name}" %>).permit(<%= attributes_names.map { |name| ":#{name}" }.join(', ') %>)
-    <%- end -%>
   end
 end
 <% end -%>

--- a/lib/generators/rails/templates/representer.rb
+++ b/lib/generators/rails/templates/representer.rb
@@ -1,6 +1,8 @@
+<% module_namespacing do -%>
 module <%= class_name %>Representer
   include Roar::Representer::<%= format %>
   <% property_options.each do |property| %>
   <%= property -%>
   <% end %>
 end
+<% end -%>

--- a/lib/roar/rails/railtie.rb
+++ b/lib/roar/rails/railtie.rb
@@ -22,3 +22,11 @@ module Roar
     end
   end
 end
+
+class Railtie < ::Rails::Railtie
+  generators do |app|
+    Rails::Generators.configure! app.config.generators
+    Rails::Generators.hidden_namespaces.uniq!
+    require 'generators/rails/scaffold_controller_generator'
+  end
+end

--- a/lib/roar/rails/railtie.rb
+++ b/lib/roar/rails/railtie.rb
@@ -18,15 +18,13 @@ module Roar
 
           include UrlMethods  # provide an initial #default_url_options.
         end
+
+        Railtie.generators do |app|
+          Railtie::Rails::Generators.configure! app.config.generators
+          Railtie::Rails::Generators.hidden_namespaces.uniq!
+          require 'generators/rails/scaffold_controller_generator'
+        end
       end
     end
-  end
-end
-
-class Railtie < ::Rails::Railtie
-  generators do |app|
-    Rails::Generators.configure! app.config.generators
-    Rails::Generators.hidden_namespaces.uniq!
-    require 'generators/rails/scaffold_controller_generator'
   end
 end

--- a/roar-rails.gemspec
+++ b/roar-rails.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "activerecord"
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "tzinfo" # FIXME: why the hell do we need this for 3.1?
+  s.add_development_dependency "pry" # FIXME: why the hell do we need this for 3.1?
 end

--- a/test/collection_representer_generator_test.rb
+++ b/test/collection_representer_generator_test.rb
@@ -1,0 +1,32 @@
+require 'test_helper'
+require 'rails/generators'
+
+require 'generators/rails/collection_representer_generator'
+
+class CollectionRepresenterGeneratorTest < Rails::Generators::TestCase
+  destination File.join(Rails.root, "tmp")
+  setup :prepare_destination
+  tests Rails::Generators::CollectionRepresenterGenerator
+
+  test "create a representer with correct class_name" do
+    run_generator %w(singer)
+
+    assert_file representer_path('singer'), /module SingersRepresenter/
+  end
+
+  test "create a representer with default json support" do
+    run_generator %w(singer)
+
+    assert_file representer_path('singer'), /include Roar::Representer::JSON::Collection/
+  end
+
+  test "create a representer with different format support" do
+    run_generator %w(singer --format=XML)
+
+    assert_file representer_path('singer'), /include Roar::Representer::XML::Collection/
+  end
+
+  def representer_path(name)
+    "app/representers/#{name.pluralize}_representer.rb"
+  end
+end

--- a/test/collection_representer_generator_test.rb
+++ b/test/collection_representer_generator_test.rb
@@ -1,6 +1,5 @@
 require 'test_helper'
 require 'rails/generators'
-
 require 'generators/rails/collection_representer_generator'
 
 class CollectionRepresenterGeneratorTest < Rails::Generators::TestCase
@@ -14,16 +13,16 @@ class CollectionRepresenterGeneratorTest < Rails::Generators::TestCase
     assert_file representer_path('singer'), /module SingersRepresenter/
   end
 
-  test "create a representer with default json support" do
+  test "create a representer with collection support" do
     run_generator %w(singer)
 
-    assert_file representer_path('singer'), /include Roar::Representer::JSON::Collection/
+    assert_file representer_path('singer'), /include Representable::JSON::Collection/
   end
 
-  test "create a representer with different format support" do
-    run_generator %w(singer --format=XML)
+  test "extend the correct representer" do
+    run_generator %w(singer)
 
-    assert_file representer_path('singer'), /include Roar::Representer::XML::Collection/
+    assert_file representer_path('singer'), /items extend: SingerRepresenter, class: Singer/
   end
 
   def representer_path(name)

--- a/test/controller_scaffold_generator_test.rb
+++ b/test/controller_scaffold_generator_test.rb
@@ -1,46 +1,45 @@
 require 'test_helper'
-require 'rails/generators'
+require 'rails/generators/test_case'
 
 require 'generators/rails/scaffold_controller_generator'
 
 class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
-  tests Rails::Generators::ScaffoldControllerGenerator
-  arguments %w(Post title body:text)
-  destination File.expand_path('../tmp', __FILE__)
-  setup :prepare_destination
+  if Rails::VERSION::STRING >= "4.0"
+    tests Rails::Generators::ScaffoldControllerGenerator
+    arguments %w(Post title body:text)
+    destination File.expand_path('../tmp', __FILE__)
+    setup :prepare_destination
 
-  test 'controller content' do
-    run_generator
+    test 'controller content' do
+      run_generator
 
-    assert_file 'app/controllers/posts_controller.rb' do |content|
-      assert_instance_method :index, content do |m|
-        assert_match /@posts = Post\.all/, m
-        assert_match /respond_with @posts, :represent_with => PostsRepresenter/, m
+      assert_file 'app/controllers/posts_controller.rb' do |content|
+        assert_instance_method :index, content do |m|
+          assert_match /@posts = Post\.all/, m
+          assert_match /respond_with @posts, :represent_with => PostsRepresenter/, m
+        end
+
+        assert_instance_method :show, content do |m|
+          assert_match /respond_with @post, :represent_with => PostRepresenter/, m
+        end
+
+        assert_instance_method :create, content do |m|
+          assert_match /@post = consume! Post\.new, :represent_with => PostRepresenter/, m
+          assert_match /@post\.save/, m
+          assert_match /respond_with @post, :represent_with => PostRepresenter/, m
+        end
+
+        assert_instance_method :update, content do |m|
+          assert_match /consume! @post, :represent_with => PostRepresenter/, m
+          assert_match /@post\.save/, m
+          assert_match /respond_with @post, :represent_with => PostRepresenter/, m
+        end
+
+        assert_instance_method :destroy, content do |m|
+          assert_match /@post\.destroy/, m
+          assert_match /head :no_content/, m
+        end
       end
-
-      assert_instance_method :show, content do |m|
-        assert_match /respond_with @post, :represent_with => PostRepresenter/, m
-      end
-
-      assert_instance_method :create, content do |m|
-        assert_match /@post = consume! Post\.new, :represent_with => PostRepresenter/, m
-        assert_match /@post\.save/, m
-        assert_match /respond_with @post, :represent_with => PostRepresenter/, m
-      end
-
-      assert_instance_method :update, content do |m|
-        assert_match /consume! @post, :represent_with => PostRepresenter/, m
-        assert_match /@post\.save/, m
-        assert_match /respond_with @post, :represent_with => PostRepresenter/, m
-      end
-
-      assert_instance_method :destroy, content do |m|
-        assert_match /@post\.destroy/, m
-        assert_match /head :no_content/, m
-      end
-
-      assert_match(/def post_params/, content)
-      assert_match(/params\.require\(:post\)\.permit\(:title, :body\)/, content)
     end
   end
 end

--- a/test/controller_scaffold_generator_test.rb
+++ b/test/controller_scaffold_generator_test.rb
@@ -1,0 +1,46 @@
+require 'test_helper'
+require 'rails/generators'
+
+require 'generators/rails/scaffold_controller_generator'
+
+class ScaffoldControllerGeneratorTest < Rails::Generators::TestCase
+  tests Rails::Generators::ScaffoldControllerGenerator
+  arguments %w(Post title body:text)
+  destination File.expand_path('../tmp', __FILE__)
+  setup :prepare_destination
+
+  test 'controller content' do
+    run_generator
+
+    assert_file 'app/controllers/posts_controller.rb' do |content|
+      assert_instance_method :index, content do |m|
+        assert_match /@posts = Post\.all/, m
+        assert_match /respond_with @posts, :represent_with => PostsRepresenter/, m
+      end
+
+      assert_instance_method :show, content do |m|
+        assert_match /respond_with @post, :represent_with => PostRepresenter/, m
+      end
+
+      assert_instance_method :create, content do |m|
+        assert_match /@post = consume! Post\.new, :represent_with => PostRepresenter/, m
+        assert_match /@post\.save/, m
+        assert_match /respond_with @post, :represent_with => PostRepresenter/, m
+      end
+
+      assert_instance_method :update, content do |m|
+        assert_match /consume! @post, :represent_with => PostRepresenter/, m
+        assert_match /@post\.save/, m
+        assert_match /respond_with @post, :represent_with => PostRepresenter/, m
+      end
+
+      assert_instance_method :destroy, content do |m|
+        assert_match /@post\.destroy/, m
+        assert_match /head :no_content/, m
+      end
+
+      assert_match(/def post_params/, content)
+      assert_match(/params\.require\(:post\)\.permit\(:title, :body\)/, content)
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,6 +5,17 @@ ENV['RAILS_ENV'] = 'test'
 require "dummy/config/environment"
 require "rails/test_help" # adds stuff like @routes, etc.
 require "roar/rails/test_case"
+require "active_support/test_case"
+
+require "bundler/setup"
+require "rails/version"
+
+if Rails::VERSION::STRING > "4.0"
+    require "active_support/testing/autorun"
+else
+    require "test/unit"
+end
+
 
 Singer = Struct.new(:name)
 


### PR DESCRIPTION
This is a PR request to integrate Roar with Rails' `scaffold_controller` functionality. This is a feature in both [jbuilder](https://github.com/rails/jbuilder) and [active_model_serializers](https://github.com/rails-api/active_model_serializers) that I liked, so I decided to do a Roar-inspired version of it.

When a user executes `rails generate scaffold_controller Model`, it will now build out the stubbing for Roar including controller methods and Representers.

I am asking for a some feedback on this because I do not know 100% if my default settings would be considered optimal, and I would love feedback to know what would be considered most 'sane' so users can get the best Roar-Rails experience with minimal effort. Please please please let me know if you think things can be done better and I will fix it! I have enjoyed this Gem greatly so glad I can help.
