### PR TITLE
generator to create representer with decorator pattern

### DIFF
--- a/lib/generators/rails/representer_generator.rb
+++ b/lib/generators/rails/representer_generator.rb
@@ -9,8 +9,11 @@ module Rails
       class_option :format, :default => :json, :banner => "--format=JSON",
         :desc => "Use different formats JSON, JSON::HAL or XML"
 
+      class_option :decorator, type: :boolean, aliases: "-d", banner: "--decorator or -d", desc: "Use decorator instead of extend"
+
       def generate_representer_file
-        template('representer.rb', file_path)
+        template = options[:decorator] ? 'decorator.rb' : 'representer.rb'
+        template(template, file_path)
       end
 
       private

--- a/lib/generators/rails/templates/decorator.rb
+++ b/lib/generators/rails/templates/decorator.rb
@@ -1,0 +1,6 @@
+class <%= class_name %>Representer < Roar::Decorator
+  include Roar::Representer::<%= format %>
+  <% property_options.each do |property| %>
+  <%= property -%>
+  <% end %>
+end

--- a/test/representer_generator_test.rb
+++ b/test/representer_generator_test.rb
@@ -14,6 +14,12 @@ class RepresentetGeneratorTest < Rails::Generators::TestCase
     assert_file representer_path('singer'), /module SingerRepresenter/
   end
 
+  test "create a representer using using the decorator pattern" do
+    run_generator %w(singer -d)
+
+    assert_file representer_path('singer'), /class SingerRepresenter < Roar::Decorator/
+  end
+
   test "create a representer with correct properties" do
     run_generator %w(singer name id)
 


### PR DESCRIPTION
Added an option to the generator to create representers using the decorator pattern 

`bin/rails g representer -d Singer` or `bin/rails g representer --decorator Singer` generates:

``` ruby
class Singer < Roar::Decorator
end
```
