### PR TITLE
Gem sorting is important

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -25,11 +25,11 @@ Add it to your app's `Gemfile`.
 gem "roar-rails"
 ```
 
-Note: For Rails >= 4.2, you need to add the `responders` gem, too, if you use `respond_with`.
-
+Note: For Rails >= 4.2, you need to add the `responders` gem, too, if you use `respond_with`. This has to be before the `roar-rails` entry in the Gemfile.
 
 ```ruby
 gem "responders"
+gem "roar-rails"
 ```
 
 ## Generators


### PR DESCRIPTION
This notes that the `responders` gem must be before the `roar-rails` gem in the gemfile. I don't know if this is the case for Rails < 5, but it's the case running the current Rails 5 alpha. I don't see how it can hurt in earlier versions of Rails, so I think the change is pretty safe.