### PR TITLE
Fix example code on using decorators in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -184,6 +184,7 @@ If you prefer roar's decorator approach over extend, just go for it. roar-rails 
 ```ruby
 class SingerRepresenter < Roar::Decorator
   include Roar::JSON
+  include Roar::Hypermedia
 
   property :name
 


### PR DESCRIPTION
It does not look like using `link` method works without importing the
Roar::Hypermedia module.