### PR TITLE
Call model.model_name.name instead of model.class.name to determine responder path.

### DIFF
--- a/lib/roar/rails/formats.rb
+++ b/lib/roar/rails/formats.rb
@@ -42,7 +42,7 @@ module Roar::Rails
     end
 
     def entity_representer(format, model, controller_path)
-      model_name = model.class.name.underscore
+      model_name = model.model_name.name.underscore
 
       if namespace = controller_path.namespace
         model_name = "#{namespace}/#{model_name}"


### PR DESCRIPTION
ActiveModel supports a #model_name method which returns a class providing information
about the model name, and removes the need to infer this from the class heirarchy.

The default model_name can also be over-ridden, which is especially useful to have
rails treat all sub-classes of an STI base model the same (using the base path) for
view and other related file lookups. This change makes that same over-ride also apply to representer lookups.

See also http://stackoverflow.com/questions/29527156/rails-sti-override-model-name-in-parent-class-for-all-subclasses
