### PR TITLE
Use uber < 0.1.0 for now

### DIFF
--- a/roar-rails.gemspec
+++ b/roar-rails.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "test_xml",      ">= 0.1.6"  # TODO: remove dependency as most people don't use XML.
   s.add_runtime_dependency "actionpack"
   s.add_runtime_dependency "railties",      ">= 3.0.0"
-  s.add_runtime_dependency "uber",          ">= 0.0.5"
+  s.add_runtime_dependency "uber",          "~> 0.0.5"
   s.add_runtime_dependency "responders"
 
   s.add_development_dependency "minitest"


### PR DESCRIPTION
Since this gem depends on Uber::Version to work and it has been removed on 0.1.0.