### PR TITLE
fix rails 5.1 loading

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -47,3 +47,12 @@ appraise 'rails-5.0' do
   gem 'activerecord', '~> 5.0.0'
   gem 'minitest-rails', '~> 3.0'
 end
+
+appraise 'rails-5.1' do
+  gem 'railties',     '~> 5.1.0'
+  gem 'actionpack',   '~> 5.1.0'
+
+  gem 'activemodel',  '~> 5.1.0'
+  gem 'activerecord', '~> 5.1.0'
+  gem 'minitest-rails', '~> 3.0'
+end

--- a/lib/roar-rails.rb
+++ b/lib/roar-rails.rb
@@ -35,6 +35,8 @@ module Roar
       require 'roar/rails/rails4_2_strategy'
     when Gem::Version.new(5.0)
       require 'roar/rails/rails5_0_strategy'
+    when Gem::Version.new("5.1")
+      require 'roar/rails/rails5_0_strategy'
     else
       # fallback to 4.0 strategy
       require 'roar/rails/rails4_0_strategy'


### PR DESCRIPTION
Rails 5.1 generators were crashing with the familiar `uninitialized constant ActionController::Responder` error.

This simple fix resolves that by using the Rails 5 bootstrap strategy.